### PR TITLE
Add data_processor module and unit test

### DIFF
--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pathlib
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from utils import data_processor
+
+
+def create_images(directory):
+    gray = (np.random.rand(128, 128) * 255).astype('uint8')
+    Image.fromarray(gray, mode='L').save(os.path.join(directory, 'gray.bmp'))
+
+    rgb = (np.random.rand(128, 128, 3) * 255).astype('uint8')
+    Image.fromarray(rgb, mode='RGB').save(os.path.join(directory, 'rgb.bmp'))
+
+    rgba = (np.random.rand(128, 128, 4) * 255).astype('uint8')
+    Image.fromarray(rgba, mode='RGBA').save(os.path.join(directory, 'rgba.png'))
+
+
+def test_data_processor(tmp_path):
+    create_images(tmp_path)
+    X, y = data_processor(str(tmp_path) + os.sep, 0)
+
+    n_images = 3
+    assert X.shape == (n_images, 49152)
+    for row in X.to_numpy():
+        assert row.reshape(128, 128, 3).shape == (128, 128, 3)
+    assert isinstance(y, pd.Series)
+    assert len(y) == n_images

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,44 @@
+import os
+import pandas as pd
+import numpy as np
+import matplotlib.image as mpimg
+from skimage.transform import resize
+
+
+def data_processor(path_to_animal: str, label: int):
+    """Process images in a directory and return flattened arrays.
+
+    Parameters
+    ----------
+    path_to_animal : str
+        Directory containing images.
+    label : int
+        Numeric label to assign to each image.
+
+    Returns
+    -------
+    (pd.DataFrame, pd.Series)
+        Flattened image data X and labels y.
+    """
+    dataframe = []
+    label_array = []
+
+    for i in os.listdir(path_to_animal):
+        if i[-3:] != 'txt':
+            img = mpimg.imread(os.path.join(path_to_animal, i))
+            img = resize(img, (128, 128), anti_aliasing=True)
+            if img.shape == (128, 128):
+                single_channel = img.reshape(128, 128, 1)
+                img = np.concatenate([single_channel] * 3, axis=-1)
+            elif img.shape == (128, 128, 4):
+                img = img[:, :, :3]
+            tensor = img.reshape(49152)
+            dataframe.append(tensor)
+    for _ in range(len(dataframe)):
+        label_array.append(label)
+    dataframe = pd.DataFrame(dataframe)
+    label_array = pd.DataFrame({'label': label_array})
+    data = pd.concat([label_array, dataframe], axis=1)
+    X = data.drop('label', axis=1)
+    y = data['label']
+    return X, y


### PR DESCRIPTION
## Summary
- extract `data_processor` from notebook into `utils.py`
- add pytest covering grayscale, RGB and RGBA image handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfc63721c832b8ef74d9b75e740e7